### PR TITLE
Prevent Block Converter Constructor Error in `XML_Transformer->data()`

### DIFF
--- a/src/transformer/class-xml-transformer.php
+++ b/src/transformer/class-xml-transformer.php
@@ -115,7 +115,7 @@ class XML_Transformer extends Transformer implements With_Setting_Fields {
 					'cursor'                       => $this->extract_by_xpath( $item, $settings[ static::PATH_CURSOR ] ?? '' ),
 					Post_Loader::BYLINE            => $this->extract_by_xpath( $item, $settings[ static::PATH_BYLINE ] ?? 'author' ),
 					Post_Loader::CONTENT           => empty( $settings[ static::DONT_CONVERT_TO_BLOCKS ] )
-						? (string) new Block_Converter( $this->extract_by_xpath( $item, $settings[ static::PATH_CONTENT ] ?? 'description' ) )
+						? (string) new Block_Converter( $this->extract_by_xpath( $item, $settings[ static::PATH_CONTENT ] ?? 'description' ) ?? '' )
 						: $this->extract_by_xpath( $item, $settings[ static::PATH_CONTENT ] ?? 'description' ),
 					Post_Loader::GUID              => $this->extract_by_xpath( $item, $settings[ static::PATH_GUID ] ?? 'guid' ),
 					Post_Loader::IMAGE             => $this->extract_by_xpath( $item, $settings[ static::PATH_IMAGE ] ?? 'image' ),


### PR DESCRIPTION
Adds null coalescing operator to `extract_by_xpath()` call in `XML_Transformer->data()` to prevent `Block_Converter` constructor error when `extract_by_xpath()` returns `null`