### PR TITLE
Bump Mantle packages and other fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "alleyinteractive/wp-block-converter": "^1.0",
-        "mantle-framework/http-client": "^0.11",
-        "mantle-framework/support": "^0.11"
+        "mantle-framework/http-client": "^0.12",
+        "mantle-framework/support": "^0.12"
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",
-        "mantle-framework/testkit": "^0.11",
+        "mantle-framework/testkit": "^0.12",
         "nunomaduro/collision": "^5.0"
     },
     "suggest": {

--- a/plugin.php
+++ b/plugin.php
@@ -21,13 +21,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Check if Composer is installed.
+/*
+ * Check whether Composer is installed in this plugin. If it's not, check for an existing Composer
+ * autoloader in case the plugin is loaded as a Composer dependency within a larger project.
+ */
 if ( file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/wordpress-autoload.php';
-/*
- * Check for an existing Composer autoloader in case the plugin is loaded as a Composer
- * dependency within a larger project.
- */
 } elseif ( ! class_exists( \Composer\InstalledVersions::class ) ) {
 	\add_action(
 		'admin_notices',

--- a/plugin.php
+++ b/plugin.php
@@ -21,8 +21,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Check if Composer is installed (remove if Composer is not required for your plugin).
-if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
+// Check if Composer is installed.
+if ( file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/wordpress-autoload.php';
+/*
+ * Check for an existing Composer autoloader in case the plugin is loaded as a Composer
+ * dependency within a larger project.
+ */
+} elseif ( ! class_exists( \Composer\InstalledVersions::class ) ) {
 	\add_action(
 		'admin_notices',
 		function() {
@@ -36,9 +42,6 @@ if ( ! file_exists( __DIR__ . '/vendor/wordpress-autoload.php' ) ) {
 
 	return;
 }
-
-// Load Composer dependencies.
-require_once __DIR__ . '/vendor/wordpress-autoload.php';
 
 /**
  * Instantiate the plugin.

--- a/src/integrations/class-byline-manager.php
+++ b/src/integrations/class-byline-manager.php
@@ -99,6 +99,8 @@ class Byline_Manager implements With_Setting_Fields {
 		}
 
 		$middleware[] = function ( array $item, Closure $next ) use ( $settings ): ?WP_Post {
+			$byline = [];
+
 			// Use the default byline from settings if configured.
 			if ( empty( $settings[ static::SETTING_USE_FEED_AUTHOR ] ) && ! empty( $settings[ static::SETTING_DEFAULT_BYLINE ] ) ) {
 				$byline = [

--- a/src/integrations/class-byline-manager.php
+++ b/src/integrations/class-byline-manager.php
@@ -98,7 +98,7 @@ class Byline_Manager implements With_Setting_Fields {
 			return $middleware;
 		}
 
-		$middleware[] = function ( array $item, Closure $next ) use ( $settings ): WP_Post {
+		$middleware[] = function ( array $item, Closure $next ) use ( $settings ): ?WP_Post {
 			// Use the default byline from settings if configured.
 			if ( empty( $settings[ static::SETTING_USE_FEED_AUTHOR ] ) && ! empty( $settings[ static::SETTING_DEFAULT_BYLINE ] ) ) {
 				$byline = [
@@ -140,7 +140,9 @@ class Byline_Manager implements With_Setting_Fields {
 
 			$post = $next( $item );
 
-			Utils::set_post_byline( $post->ID, $byline );
+			if ( $post instanceof WP_Post ) {
+				Utils::set_post_byline( $post->ID, $byline );
+			}
 
 			return $post;
 		};

--- a/src/transformer/class-xml-transformer.php
+++ b/src/transformer/class-xml-transformer.php
@@ -184,6 +184,13 @@ class XML_Transformer extends Transformer implements With_Setting_Fields {
 			return null;
 		}
 
-		return trim( $item->xpath( $xpath )[0] ?? null ) ?: null;
+		$value = null;
+		$item  = $item->xpath( $xpath );
+
+		if ( count( $item ) > 0 ) {
+			$value = trim( (string) $item[0] );
+		}
+
+		return $value;
 	}
 }

--- a/tests/extractor/test-feed-extractor.php
+++ b/tests/extractor/test-feed-extractor.php
@@ -68,7 +68,6 @@ class Feed_Extractor_Test extends Test_Case {
 		$_SERVER['__did_auth'] = false;
 
 		$this->fake_request(
-			'https://alley.com/feed/',
 			function ( string $url, array $args ) {
 				if ( ! empty( $args['headers']['Authorization'] ) ) {
 					$_SERVER['__did_auth'] = 'Basic ' . base64_encode( 'username:password' ) === $args['headers']['Authorization'];

--- a/tests/loader/test-post-loader.php
+++ b/tests/loader/test-post-loader.php
@@ -229,7 +229,6 @@ class Post_Loader_Test extends Test_Case {
 
 	public function test_image_on_posts() {
 		$this->fake_request(
-			'https://example.com/image.jpg',
 			function ( string $url, array $args ) {
 				$contents = file_get_contents( __DIR__ . '/../fixtures/alley.jpg' );
 


### PR DESCRIPTION
- Update Mantle dependencies to current Mantle versions.
- Check for an existing Composer autoloader before exiting (see https://github.com/alleyinteractive/wp-curate/blob/4e13895624706f08e23a2236ab459ab8842bd408/wp-curate.php#L29-L52).
- Update Byline Manager integration to handle `null` values from `feed_consumer_prevent_post_load` filter.