### PR TITLE
Issue-79: Last run updated on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 All notable changes to `Feed Consumer` will be documented in this file.
 
-## v1.1.2
+## v1.2.0
 
-- Only update last run time on successful run.
+- Store new meta key for last successful run time.
+- Add `feed_consumer_feed_termination` action after feed is finished running.
+- Last run time now uses `time()` instead of `current_time( 'timestamp' )`.
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Feed Consumer` will be documented in this file.
 
+## v1.1.2
+
+- Only update last run time on successful run.
+
 ## v1.1.1
 
 - Fix timezone issue when displaying next feed run time.

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Feed Consumer
  * Plugin URI: https://github.com/alleyinteractive/feed-consumer
  * Description: Ingest external feeds and other data sources into WordPress
- * Version: 1.1.2
+ * Version: 1.2.0
  * Author: Sean Fisher
  * Author URI: https://github.com/alleyinteractive/feed-consumer
  * Requires at least: 6.5

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Feed Consumer
  * Plugin URI: https://github.com/alleyinteractive/feed-consumer
  * Description: Ingest external feeds and other data sources into WordPress
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: Sean Fisher
  * Author URI: https://github.com/alleyinteractive/feed-consumer
  * Requires at least: 6.5

--- a/src/class-runner.php
+++ b/src/class-runner.php
@@ -295,11 +295,12 @@ class Runner {
 	 */
 	protected function after_run( bool $successful ): void {
 		// Update the last run time of the feed.
-		update_post_meta( $this->feed_id, static::LAST_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+		$timestamp = time();
+		update_post_meta( $this->feed_id, static::LAST_RUN_META_KEY, $timestamp );
 
 		// Update the last successful run time of the feed.
 		if ( $successful ) {
-			update_post_meta( $this->feed_id, static::LAST_SUCCESSFUL_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+			update_post_meta( $this->feed_id, static::LAST_SUCCESSFUL_RUN_META_KEY, $timestamp );
 		}
 
 		/**
@@ -311,7 +312,7 @@ class Runner {
 		 * @param bool $successful Whether or not the run was successful.
 		 * @param int  $timestamp The current timestamp that will be stored in meta keys.
 		 */
-		do_action( 'feed_consumer_feed_termination', $this->feed_id, $successful, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+		do_action( 'feed_consumer_feed_termination', $this->feed_id, $successful, $timestamp );
 
 		// Schedule the next run of the feed.
 		static::schedule_next_run( $this->feed_id );

--- a/src/class-runner.php
+++ b/src/class-runner.php
@@ -206,7 +206,7 @@ class Runner {
 				->run();
 		} catch ( Throwable $e ) {
 			$this->logger?->error( 'Error running feed extractor', [ 'exception' => $e ] );
-			$this->after_run();
+			$this->after_run( false );
 			return;
 		}
 
@@ -220,7 +220,7 @@ class Runner {
 				->data();
 		} catch ( Throwable $e ) {
 			$this->logger?->error( 'Error running feed transformer', [ 'exception' => $e ] );
-			$this->after_run();
+			$this->after_run( false );
 			return;
 		}
 
@@ -243,7 +243,7 @@ class Runner {
 				->load();
 		} catch ( Throwable $e ) {
 			$this->logger?->error( 'Error running feed loader', [ 'exception' => $e ] );
-			$this->after_run();
+			$this->after_run( false );
 			return;
 		}
 
@@ -278,15 +278,19 @@ class Runner {
 			}
 		}
 
-		$this->after_run();
+		$this->after_run( true );
 	}
 
 	/**
 	 * Actions to perform after the feed has run.
+	 *
+	 * @param bool $successful Whether the run was successful.
 	 */
-	protected function after_run(): void {
-		// Update the last run time of the feed.
-		update_post_meta( $this->feed_id, static::LAST_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+	protected function after_run( bool $successful ): void {
+		if ( $successful ) {
+			// Update the last run time of the feed.
+			update_post_meta( $this->feed_id, static::LAST_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+		}
 
 		// Schedule the next run of the feed.
 		static::schedule_next_run( $this->feed_id );

--- a/src/class-runner.php
+++ b/src/class-runner.php
@@ -32,6 +32,13 @@ class Runner {
 	public const LAST_RUN_META_KEY = 'feed_consumer_last_run';
 
 	/**
+	 * Meta key to store the last successful run time.
+	 *
+	 * @var string
+	 */
+	public const LAST_SUCCESSFUL_RUN_META_KEY = 'feed_consumer_last_successful_run';
+
+	/**
 	 * Cron hook of the runner.
 	 *
 	 * @var string
@@ -287,10 +294,24 @@ class Runner {
 	 * @param bool $successful Whether the run was successful.
 	 */
 	protected function after_run( bool $successful ): void {
+		// Update the last run time of the feed.
+		update_post_meta( $this->feed_id, static::LAST_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+
+		// Update the last successful run time of the feed.
 		if ( $successful ) {
-			// Update the last run time of the feed.
-			update_post_meta( $this->feed_id, static::LAST_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+			update_post_meta( $this->feed_id, static::LAST_SUCCESSFUL_RUN_META_KEY, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 		}
+
+		/**
+		 * Fires when feed run completed.
+		 *
+		 * @since 1.1.2
+		 *
+		 * @param int  $feed_id The feed id.
+		 * @param bool $successful Whether or not the run was successful.
+		 * @param int  $timestamp The current timestamp that will be stored in meta keys.
+		 */
+		do_action( 'feed_consumer_feed_termination', $this->feed_id, $successful, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 
 		// Schedule the next run of the feed.
 		static::schedule_next_run( $this->feed_id );

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -397,7 +397,6 @@ class Settings {
 			printf( '<strong>%s</strong>', esc_html__( 'Feed is not published.', 'feed-consumer' ) );
 			return;
 		}
-		$gmt_offset = get_option( 'gmt_offset' );
 
 		// Fetch the next run time and display it.
 		try {
@@ -417,7 +416,7 @@ class Settings {
 				printf(
 					'<strong>%s</strong> <time datetime="%s">%s</time>',
 					esc_html__( 'Next run:', 'feed-consumer' ),
-					esc_attr( date_i18n( 'c', $next_run ) ),
+					esc_attr( wp_date( 'c', $next_run ) ),
 					esc_html(
 						sprintf(
 							/* translators: %s: Human readable time difference. */
@@ -443,8 +442,8 @@ class Settings {
 			printf(
 				'<p><strong>%s</strong> <time datetime="%s">%s</time></p>',
 				esc_html__( 'Last run:', 'feed-consumer' ),
-				esc_attr( date_i18n( 'c', $last_run ) ),
-				esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $last_run + $gmt_offset * HOUR_IN_SECONDS ) ),
+				esc_attr( wp_date( 'c', $last_run ) ),
+				esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $last_run ) ),
 			);
 		}
 	}

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -397,6 +397,7 @@ class Settings {
 			printf( '<strong>%s</strong>', esc_html__( 'Feed is not published.', 'feed-consumer' ) );
 			return;
 		}
+		$gmt_offset = get_option( 'gmt_offset' );
 
 		// Fetch the next run time and display it.
 		try {
@@ -443,7 +444,7 @@ class Settings {
 				'<p><strong>%s</strong> <time datetime="%s">%s</time></p>',
 				esc_html__( 'Last run:', 'feed-consumer' ),
 				esc_attr( date_i18n( 'c', $last_run ) ),
-				esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $last_run ) ),
+				esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $last_run + $gmt_offset * HOUR_IN_SECONDS ) ),
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #79

## Description

This pull request addresses an issue where the system would update a feed's last run time even when the feed run failed due to errors (such as when the remote source is unavailable). With this fix, the last run time will now only be updated if the feed run is successful. The implementation introduces a boolean parameter to the `after_run()` method to explicitly indicate success or failure, updating the last run timestamp only on successful runs. All relevant method calls have been updated to reflect this logic.

Additionally, the plugin version has been incremented from 1.1.1 to 1.1.2, and the change is documented in `CHANGELOG.md`.

## Steps to Reproduce

1. Configure a feed in a way that it will fail (e.g., use a bad URL).
2. Run the feed.
3. Check the last run time to confirm it is only updated upon successful runs.

## Changelog

- Only update a feed's last run time after a successful run.
- Bump plugin version to 1.1.2.

## Additional Notes

N/A